### PR TITLE
Agrega herramienta de sincronización manual PORTICO en Sistemas

### DIFF
--- a/app/Console/Commands/SyncPortico.php
+++ b/app/Console/Commands/SyncPortico.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\IntegrantesSocio;
+use App\Models\Membresias;
+use App\Models\Socio;
+use App\Models\SocioMembresia;
+use Illuminate\Console\Command;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Envía un snapshot de socios, membresías e integrantes (con sus fotos) a la
+ * API PORTICO, desde donde la app de escritorio PorticoVV los consume.
+ *
+ * Solo se envían los campos necesarios para el control de acceso; no se
+ * exponen datos personales sensibles (dirección, teléfonos, CURP, RFC, correos).
+ */
+class SyncPortico extends Command
+{
+    protected $signature = 'sync:portico {--sin-imagenes : Enviar solo los datos, omitir la subida de fotos}';
+
+    protected $description = 'Sincroniza socios, membresías e integrantes hacia la API PORTICO';
+
+    public function handle(): int
+    {
+        $url = rtrim((string) config('portico.api_url'), '/');
+
+        // La API es de acceso público (sin API key). Solo se requiere la URL.
+        if ($url === '') {
+            $this->error('Falta PORTICO_API_URL en el archivo .env');
+            return self::FAILURE;
+        }
+
+        // 1. Recolectar datos (Socio excluye borrados por SoftDeletes).
+        $socios = Socio::query()
+            ->select('id', 'nombre', 'apellido_p', 'apellido_m', 'img_path')
+            ->get();
+
+        $membresias = Membresias::query()
+            ->select('clave', 'descripcion')
+            ->get();
+
+        // Solo membresías de socios vigentes. Se usa whereExists (en vez de
+        // whereIn con todos los ids) para que escale con miles de socios.
+        $sociosMembresias = SocioMembresia::query()
+            ->select('id', 'id_socio', 'clave_membresia', 'estado')
+            ->whereExists(fn ($q) => $q->from('socios')
+                ->whereColumn('socios.id', 'socios_membresias.id_socio')
+                ->whereNull('socios.deleted_at'))
+            ->get();
+
+        // IntegrantesSocio no usa SoftDeletes: filtrar borrados manualmente y
+        // solo los que pertenecen a un socio vigente (whereExists, escalable).
+        $integrantes = IntegrantesSocio::query()
+            ->select(
+                'id',
+                'id_socio',
+                'nombre_integrante',
+                'apellido_p_integrante',
+                'apellido_m_integrante',
+                'img_path_integrante',
+                'parentesco'
+            )
+            ->whereNull('deleted_at')
+            ->whereExists(fn ($q) => $q->from('socios')
+                ->whereColumn('socios.id', 'integrantes_socios.id_socio')
+                ->whereNull('socios.deleted_at'))
+            ->get();
+
+        // 2. Enviar el snapshot completo.
+        $this->info(sprintf(
+            'Enviando %d socios, %d membresías, %d socios_membresías, %d integrantes...',
+            $socios->count(),
+            $membresias->count(),
+            $sociosMembresias->count(),
+            $integrantes->count()
+        ));
+
+        try {
+            $respuesta = Http::acceptJson()
+                ->timeout(60)
+                ->post("{$url}/api/portico/sync", [
+                    'socios'            => $socios,
+                    'membresias'        => $membresias,
+                    'socios_membresias' => $sociosMembresias,
+                    'integrantes'       => $integrantes,
+                ]);
+        } catch (ConnectionException $e) {
+            $this->error("No se pudo conectar con la API: {$e->getMessage()}");
+            return self::FAILURE;
+        }
+
+        if ($respuesta->failed()) {
+            $this->error("Error al sincronizar datos: HTTP {$respuesta->status()}");
+            $this->line($respuesta->body());
+            return self::FAILURE;
+        }
+
+        $this->info('Datos sincronizados correctamente.');
+
+        // 3. Subir SOLO las imágenes que la API pide (cambiadas o faltantes).
+        if (! $this->option('sin-imagenes')) {
+            $requeridas = $respuesta->json('imagenes_requeridas', ['socio' => [], 'integrante' => []]);
+            $this->subirImagenes($url, $socios, $integrantes, $requeridas);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Sube en paralelo (por lotes) las fotos que la API pidió, con un reintento
+     * por imagen fallida.
+     */
+    private function subirImagenes(string $url, $socios, $integrantes, array $requeridas): void
+    {
+        $disk = Storage::disk('public');
+
+        // IDs que la API pidió (cambiados o faltantes); el resto no se re-sube.
+        $idsSocios      = array_flip($requeridas['socio'] ?? []);
+        $idsIntegrantes = array_flip($requeridas['integrante'] ?? []);
+
+        // Solo los que la API pide y cuyo archivo existe en disco.
+        $items = [];
+        $omitidas = 0;
+        foreach ($socios as $s) {
+            if (! empty($s->img_path) && isset($idsSocios[$s->id])) {
+                if ($disk->exists($s->img_path)) {
+                    $items[] = ['socio', $s->id, $s->img_path];
+                } else {
+                    $omitidas++;
+                }
+            }
+        }
+        foreach ($integrantes as $i) {
+            if (! empty($i->img_path_integrante) && isset($idsIntegrantes[$i->id])) {
+                if ($disk->exists($i->img_path_integrante)) {
+                    $items[] = ['integrante', $i->id, $i->img_path_integrante];
+                } else {
+                    $omitidas++;
+                }
+            }
+        }
+
+        if ($items === []) {
+            $this->info($omitidas > 0
+                ? "No hay imágenes que subir ({$omitidas} sin archivo en disco)."
+                : 'No hay imágenes nuevas o modificadas que subir.');
+            return;
+        }
+
+        $this->info('Subiendo ' . count($items) . ' imágenes...');
+        $bar = $this->output->createProgressBar(count($items));
+        $bar->start();
+
+        $subidas = 0;
+        $fallidas = 0;
+
+        // Subir de a 5 en paralelo; reintentar una vez las que fallen.
+        foreach (array_chunk($items, 5) as $grupo) {
+            $resultado = $this->subirLote($url, $disk, $grupo);
+
+            $fallaron = [];
+            foreach ($grupo as $idx => $item) {
+                if ($resultado[$idx] ?? false) {
+                    $subidas++;
+                } else {
+                    $fallaron[] = $item;
+                }
+            }
+
+            if ($fallaron !== []) {
+                $reintento = $this->subirLote($url, $disk, $fallaron);
+                foreach ($fallaron as $idx => $item) {
+                    if ($reintento[$idx] ?? false) {
+                        $subidas++;
+                    } else {
+                        $fallidas++;
+                    }
+                }
+            }
+
+            $bar->advance(count($grupo));
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Imágenes: {$subidas} subidas, {$omitidas} sin archivo, {$fallidas} con error.");
+    }
+
+    /**
+     * Sube un lote de imágenes en paralelo. Devuelve [índice => bool éxito].
+     */
+    private function subirLote(string $url, $disk, array $grupo): array
+    {
+        try {
+            $respuestas = Http::pool(fn (Pool $pool) => collect($grupo)
+                ->map(fn ($item) => $pool->timeout(60)
+                    ->attach('image', $disk->get($item[2]), basename($item[2]))
+                    ->post("{$url}/api/portico/images/{$item[0]}/{$item[1]}"))
+                ->all());
+        } catch (\Throwable $e) {
+            // Si el lote entero falla (ej. error de conexión), marcar todo fallido.
+            return array_fill(0, count($grupo), false);
+        }
+
+        $exitos = [];
+        foreach ($respuestas as $idx => $resp) {
+            // En un pool, un request con error de conexión devuelve un Throwable
+            // en lugar de una Response.
+            $exitos[$idx] = $resp instanceof \Illuminate\Http\Client\Response && $resp->successful();
+        }
+
+        return $exitos;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,7 +12,13 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
+        // Envía los datos a la API PORTICO en horarios fijos: 00:00, 06:00,
+        // 12:00 y 18:00. La app de escritorio los descarga 5 min después
+        // (00:05, 06:05, ...), cuando la API ya tiene los datos frescos.
+        $schedule->command('sync:portico')
+            ->cron('0 0,6,12,18 * * *')
+            ->withoutOverlapping()
+            ->runInBackground();
     }
 
     /**

--- a/app/Http/Controllers/SistemasController.php
+++ b/app/Http/Controllers/SistemasController.php
@@ -19,6 +19,7 @@ use App\Models\ZonaImpresion;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Facades\Excel;
 
@@ -27,6 +28,26 @@ class SistemasController extends Controller
     public function editarCuotas(Socio $socio)
     {
         return view('sistemas.Recepcion.editar-cuotas', ['socio' => $socio]);
+    }
+
+    /**
+     * Ejecuta manualmente la sincronización con la API PORTICO (el mismo comando
+     * que corre en automático cada 6 horas). Se usa desde el botón en el módulo
+     * de Sistemas → Herramientas.
+     */
+    public function sincronizarPortico()
+    {
+        try {
+            $codigo = Artisan::call('sync:portico');
+
+            if ($codigo === 0) {
+                return back()->with('success', 'Sincronización con PORTICO completada correctamente.');
+            }
+
+            return back()->with('fail', 'La sincronización con PORTICO terminó con errores. Revisa los registros.');
+        } catch (\Throwable $e) {
+            return back()->with('fail', 'No se pudo sincronizar con PORTICO: ' . $e->getMessage());
+        }
     }
 
     public function prodVendidos()

--- a/config/portico.php
+++ b/config/portico.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | API PORTICO
+    |--------------------------------------------------------------------------
+    | URL base de la API intermediaria (ResellerClub) a la que el comando
+    | "sync:portico" envía los datos para la app de escritorio PorticoVV.
+    */
+    'api_url' => env('PORTICO_API_URL'),
+];

--- a/resources/views/sistemas/Herramientas/portico.blade.php
+++ b/resources/views/sistemas/Herramientas/portico.blade.php
@@ -1,0 +1,33 @@
+<x-app-layout>
+    {{-- Sub barra de navegacion --}}
+    <x-slot name="header">
+        @include('sistemas.nav')
+    </x-slot>
+
+    {{-- Contenido --}}
+    <div class="flex items-center m-2">
+        <h4 class="text-2xl font-bold dark:text-white mx-2">Sincronización PORTICO</h4>
+    </div>
+
+    <div class="ms-3 mx-3 max-w-2xl">
+        <form action="{{ route('sistemas.portico.sync') }}" method="POST">
+            @csrf
+            <button type="submit"
+                class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none">
+                Sincronizar ahora
+            </button>
+        </form>
+
+        {{-- Mensajes --}}
+        @if (session('success'))
+            <div class="mt-4 p-3 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400">
+                {{ session('success') }}
+            </div>
+        @endif
+        @if (session('fail'))
+            <div class="mt-4 p-3 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400">
+                {{ session('fail') }}
+            </div>
+        @endif
+    </div>
+</x-app-layout>

--- a/resources/views/sistemas/nav.blade.php
+++ b/resources/views/sistemas/nav.blade.php
@@ -187,6 +187,10 @@
                                 <a href="{{ route('sistemas.reportes') }}"
                                     class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">Reportes</a>
                             </li>
+                            <li>
+                                <a href="{{ route('sistemas.portico') }}"
+                                    class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">Sincronizar Portico</a>
+                            </li>
                         </ul>
                     </div>
                 </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -317,6 +317,10 @@ Route::prefix('sistemas')->middleware(['auth', 'sistemas'])->group(function () {
         Route::post('/recibos-mes', [ReportesController::class, 'recibosMes'])->name('sistemas.reportes.recibos');
         Route::post('/socios-actuales', [ReportesController::class, 'socios'])->name('sistemas.reportes.socios');
     });
+    Route::prefix('portico')->group(function () {
+        Route::view('/', 'sistemas.Herramientas.portico')->name('sistemas.portico');
+        Route::post('/sincronizar', [SistemasController::class, 'sincronizarPortico'])->name('sistemas.portico.sync');
+    });
 
     //RECEPCION
     Route::prefix('recepcion')->group(function () {


### PR DESCRIPTION
Suma vista y ruta en Herramientas para disparar sync:portico desde la UI, y remueve la API key del comando de sincronización y su config.